### PR TITLE
Fix the "No rule to make target 'BRPYTHON'" error during initial repository compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 1. **克隆本项目**
 
 ```shell
-git clone https://github.com/yaozhicheng/NEMU.git
+git clone --recurse-submodules https://github.com/yaozhicheng/NEMU.git
 ```
 
 2. **设置 $NEMU_HOME**

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -86,8 +86,8 @@ $(BINARY): $(OBJS) $(LIBS)
 	@echo + $(LD) $@
 	@$(LD) -o $@ $(OBJS) $(LDFLAGS) $(LIBS)
 
-ifdef CONFIG_ENABLE_BRANCH_TRACE
 BRPYTHON: $(OBJS) $(LIBS) $(BINARY)
+ifdef CONFIG_ENABLE_BRANCH_TRACE
 	mkdir -p $(BUILD_DIR)/NemuBR
 	mv src/base/NemuBR.py $(BUILD_DIR)/NemuBR/__init__.py
 	@$(LD) -o $(BUILD_DIR)/NemuBR/_NemuBR.so $(OBJS) $(LDFLAGS) -shared -rdynamic -fPIC -lz $(LIBS)


### PR DESCRIPTION
Fix the bug that occurs when compiling the initial repository, resulting in the error: "No rule to make target 'BRPYTHON', needed by 'app'."